### PR TITLE
Update Travis config to prevent rubocop from running against Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,21 @@
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
@@ -9,3 +27,24 @@ Metrics/MethodLength:
   Max: 15
   Exclude:
     - "**/*_spec.rb"
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 install:
   - bundle install --jobs=3 --retry=3
-  - gem install rubocop
+  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || gem install rubocop
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -23,7 +23,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - rubocop
+  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || rubocop
   - bundle exec rake
 
 after_script:


### PR DESCRIPTION
Update Rubocop config to support 0.85 spec cops