### PR TITLE
Update applicant and note APIs to support OK response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,50 +1,25 @@
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
+require:
+  - rubocop-rake
+  - rubocop-rspec
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.5
 
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
+Layout/LineLength:
+  Max: 120
 
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
-
-Metrics/LineLength:
-  Max: 120
 
 Metrics/MethodLength:
   Max: 15
   Exclude:
     - "**/*_spec.rb"
 
-Style/ExponentialNotation:
-  Enabled: true
+RSpec/ExampleLength:
+  Max: 15
 
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
+RSpec/MultipleExpectations:
+  Max: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ env:
 language: ruby
 
 rvm:
-  - 2.3
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
+  - 3.0
 
 before_install:
   - gem update bundler
 
 install:
   - bundle install --jobs=3 --retry=3
-  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || gem install rubocop
+  - gem install rubocop
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -23,7 +23,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
-  - ruby --version | grep '^ruby 2\.3\.' > /dev/null || rubocop
+  - bundle exec rubocop
   - bundle exec rake
 
 after_script:

--- a/fountain.gemspec
+++ b/fountain.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Fountain REST API v2 wrapper for Ruby'
   spec.homepage      = 'https://github.com/Studiosity/fountain-ruby'
   spec.license       = 'MIT'
+  spec.required_ruby_version = ['>= 2.5.0', '< 3.1.0']
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|docs)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -22,7 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.53'
+  spec.add_development_dependency 'rubocop', '~> 1.21'
+  spec.add_development_dependency 'rubocop-rake', '~> 0.6'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.5'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'webmock', '~> 2.3'
 end

--- a/lib/fountain.rb
+++ b/lib/fountain.rb
@@ -9,12 +9,19 @@ require 'fountain/util'
 
 module Fountain
   class Error < StandardError; end
+
   class HTTPError < Error; end
+
   class NotFoundError < HTTPError; end
+
   class AuthenticationError < HTTPError; end
+
   class InvalidMethodError < HTTPError; end
+
   class JsonParseError < Error; end
+
   class MissingApiKeyError < Error; end
+
   class StatusError < Error; end
 end
 

--- a/lib/fountain/api/applicants.rb
+++ b/lib/fountain/api/applicants.rb
@@ -50,7 +50,7 @@ module Fountain
         response = request_json(
           '/v2/applicants',
           method: :post,
-          expected_response: Net::HTTPCreated,
+          expected_response: [Net::HTTPCreated, Net::HTTPOK],
           body: {
             name: name, email: email, phone_number: phone_number
           }.merge(filtered_params)

--- a/lib/fountain/api/notes.rb
+++ b/lib/fountain/api/notes.rb
@@ -26,7 +26,7 @@ module Fountain
         response = request_json(
           "/v2/applicants/#{applicant_id}/notes",
           method: :post,
-          expected_response: Net::HTTPCreated,
+          expected_response: [Net::HTTPCreated, Net::HTTPOK],
           body: { content: content }
         )
         Fountain::Note.new response

--- a/lib/fountain/api/request_helper.rb
+++ b/lib/fountain/api/request_helper.rb
@@ -40,7 +40,7 @@ module Fountain
       def check_response(response, expected_response = nil)
         expected_response ||= Net::HTTPOK
         case response
-        when expected_response then nil
+        when *[expected_response].flatten then nil
         when Net::HTTPUnauthorized then raise Fountain::AuthenticationError
         when Net::HTTPNotFound then raise Fountain::NotFoundError
         else raise HTTPError, "Invalid http response code: #{response.code}"
@@ -95,7 +95,7 @@ module Fountain
       end
 
       def create_get_request(path, headers, body)
-        path += '?' + body.map { |k, v| "#{k}=#{v}" }.join('&') if body
+        path += "?#{body.map { |k, v| "#{k}=#{v}" }.join('&')}" if body
         Net::HTTP::Get.new(path, headers)
       end
 

--- a/spec/fountain/api/applicants_spec.rb
+++ b/spec/fountain/api/applicants_spec.rb
@@ -21,6 +21,13 @@ describe Fountain::Api::Applicants do
       'name' => 'Frank'
     }
   end
+  let(:applicant3) do
+    {
+      'id' => '01234567-0000-0000-0000-000000000002',
+      'email' => 'tom@gmail.com',
+      'name' => 'Tom'
+    }
+  end
 
   describe '.list' do
     before do
@@ -103,7 +110,7 @@ describe Fountain::Api::Applicants do
         )
         .to_return(
           body: applicant1.to_json,
-          status: 201
+          status: 200
         )
 
       stub_authed_request(:post, '/v2/applicants')
@@ -121,6 +128,19 @@ describe Fountain::Api::Applicants do
         )
         .to_return(
           body: applicant2.to_json,
+          status: 200
+        )
+
+      stub_authed_request(:post, '/v2/applicants')
+        .with(
+          body: {
+            name: 'Tom',
+            email: 'tom@gmail.com',
+            phone_number: '0'
+          }.to_json
+        )
+        .to_return(
+          body: applicant3.to_json,
           status: 201
         )
     end
@@ -151,6 +171,17 @@ describe Fountain::Api::Applicants do
       expect(applicant).to be_a Fountain::Applicant
       expect(applicant.id).to eq '01234567-0000-0000-0000-000000000001'
       expect(applicant.name).to eq 'Frank'
+    end
+
+    it 'handles a 201 Created response' do
+      applicant = described_class.create(
+        'Tom',
+        'tom@gmail.com',
+        '0'
+      )
+      expect(applicant).to be_a Fountain::Applicant
+      expect(applicant.id).to eq '01234567-0000-0000-0000-000000000002'
+      expect(applicant.name).to eq 'Tom'
     end
   end
 

--- a/spec/fountain/api/applicants_spec.rb
+++ b/spec/fountain/api/applicants_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Fountain::Api::Applicants do
   before { Fountain.api_token = AUTH_TOKEN }
+
   after { Fountain.api_token = nil }
 
   let(:applicant1) do
@@ -56,7 +57,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns all applicants when passed no parameters' do
-      applicants = Fountain::Api::Applicants.list
+      applicants = described_class.list
       expect(applicants).to be_an Fountain::Applicants
 
       expect(applicants.count).to eq 2
@@ -67,7 +68,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'passes through arguments' do
-      applicants = Fountain::Api::Applicants.list funnel_id: 1234, stage_id: 4567, stage: 'Foo'
+      applicants = described_class.list funnel_id: 1234, stage_id: 4567, stage: 'Foo'
       expect(applicants).to be_an Fountain::Applicants
 
       expect(applicants.count).to eq 1
@@ -78,7 +79,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'filters out non-standard arguments' do
-      applicants = Fountain::Api::Applicants.list labels: 'Bar', cursor: 'abcd', foo: 'baz'
+      applicants = described_class.list labels: 'Bar', cursor: 'abcd', foo: 'baz'
       expect(applicants).to be_an Fountain::Applicants
 
       expect(applicants.count).to eq 1
@@ -125,7 +126,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns created applicant' do
-      applicant = Fountain::Api::Applicants.create(
+      applicant = described_class.create(
         'Richard',
         'rich@gmail.com',
         '1231231234'
@@ -136,7 +137,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'filters out non-standard arguments' do
-      applicant = Fountain::Api::Applicants.create(
+      applicant = described_class.create(
         'Frank',
         'frank@gmail.com',
         '321321311',
@@ -161,7 +162,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'deletes the applicant' do
-      result = Fountain::Api::Applicants.delete('01234567-0000-0000-0000-000000000000')
+      result = described_class.delete('01234567-0000-0000-0000-000000000000')
       expect(result).to eq true
     end
   end
@@ -177,7 +178,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns the applicant' do
-      applicant = Fountain::Api::Applicants.get('01234567-0000-0000-0000-000000000000')
+      applicant = described_class.get('01234567-0000-0000-0000-000000000000')
       expect(applicant).to be_a Fountain::Applicant
       expect(applicant.id).to eq '01234567-0000-0000-0000-000000000000'
       expect(applicant.name).to eq 'Richard'
@@ -235,7 +236,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns updated applicant' do
-      applicant = Fountain::Api::Applicants.update(
+      applicant = described_class.update(
         '01234567-0000-0000-0000-000000000000',
         name: 'Dicky',
         email: 'richard@gmail.com',
@@ -250,7 +251,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'filters out non-standard arguments' do
-      applicant = Fountain::Api::Applicants.update(
+      applicant = described_class.update(
         '01234567-0000-0000-0000-000000000001',
         name: 'Franky',
         height: '150'
@@ -261,7 +262,7 @@ describe Fountain::Api::Applicants do
 
     it 'raises a not found error if ID was not found' do
       expect do
-        Fountain::Api::Applicants.update('1234', name: 'Franky')
+        described_class.update('1234', name: 'Franky')
       end.to raise_error Fountain::NotFoundError
     end
   end
@@ -294,7 +295,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns the document' do
-      documents = Fountain::Api::Applicants.get_secure_documents('01234567-0000-0000-0000-000000000000')
+      documents = described_class.get_secure_documents('01234567-0000-0000-0000-000000000000')
       expect(documents).to be_an Array
       expect(documents.map(&:class)).to eq [Fountain::SecureDocument]
       expect(documents.map(&:id)).to eq ['a71d7cf4-2d9d-4d4b-82ef-8894bbe78120']
@@ -318,14 +319,14 @@ describe Fountain::Api::Applicants do
     end
 
     it 'advances an applicant' do
-      result = Fountain::Api::Applicants.advance_applicant(
+      result = described_class.advance_applicant(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(result).to eq true
     end
 
     it 'advances an applicant to a specific stage (ignoring non-standard arguments)' do
-      result = Fountain::Api::Applicants.advance_applicant(
+      result = described_class.advance_applicant(
         '01234567-0000-0000-0000-000000000001',
         skip_automated_actions: true,
         stage_id: 'stage-id',
@@ -358,7 +359,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns the booked slots' do
-      sessions = Fountain::Api::Applicants.get_interview_sessions(
+      sessions = described_class.get_interview_sessions(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(sessions).to be_an Array
@@ -385,7 +386,7 @@ describe Fountain::Api::Applicants do
     end
 
     it 'returns the applicants transitions' do
-      transitions = Fountain::Api::Applicants.get_transition_history(
+      transitions = described_class.get_transition_history(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(transitions).to be_an Array

--- a/spec/fountain/api/available_slots_spec.rb
+++ b/spec/fountain/api/available_slots_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Fountain::Api::AvailableSlots do
   before { Fountain.api_token = AUTH_TOKEN }
+
   after { Fountain.api_token = nil }
 
   let(:slot) do
@@ -34,7 +35,7 @@ describe Fountain::Api::AvailableSlots do
     end
 
     it 'confirms the available slot' do
-      slot = Fountain::Api::AvailableSlots.confirm(
+      slot = described_class.confirm(
         'ff4285bc-4988-4077-9ca8-ca95a765f99d',
         '01234567-0000-0000-0000-000000000000'
       )
@@ -80,7 +81,7 @@ describe Fountain::Api::AvailableSlots do
     end
 
     it 'returns first page of slots when only passed stage parameter' do
-      slots = Fountain::Api::AvailableSlots.list(
+      slots = described_class.list(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(slots).to be_an Fountain::Slots
@@ -93,7 +94,7 @@ describe Fountain::Api::AvailableSlots do
     end
 
     it 'passes through page argument' do
-      slots = Fountain::Api::AvailableSlots.list(
+      slots = described_class.list(
         '01234567-0000-0000-0000-000000000000',
         page: 3
       )
@@ -117,7 +118,7 @@ describe Fountain::Api::AvailableSlots do
     end
 
     it 'cancels a booked session' do
-      result = Fountain::Api::AvailableSlots.cancel(
+      result = described_class.cancel(
         '22222222-0000-0000-0000-000000000000'
       )
       expect(result).to eq true

--- a/spec/fountain/api/funnels_spec.rb
+++ b/spec/fountain/api/funnels_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Fountain::Api::Funnels do
   before { Fountain.api_token = AUTH_TOKEN }
+
   after { Fountain.api_token = nil }
 
   let(:funnel1) do
@@ -61,7 +62,7 @@ describe Fountain::Api::Funnels do
     end
 
     it 'returns first page of funnels when no parameters passed' do
-      funnels = Fountain::Api::Funnels.list
+      funnels = described_class.list
       expect(funnels).to be_a Fountain::Funnels
 
       expect(funnels.count).to eq 1
@@ -72,7 +73,7 @@ describe Fountain::Api::Funnels do
     end
 
     it 'passes through page argument' do
-      funnels = Fountain::Api::Funnels.list(page: 3)
+      funnels = described_class.list(page: 3)
       expect(funnels).to be_an Fountain::Funnels
 
       expect(funnels.count).to eq 1
@@ -101,7 +102,7 @@ describe Fountain::Api::Funnels do
     end
 
     it 'updates funnel' do
-      funnel = Fountain::Api::Funnels.update(
+      funnel = described_class.update(
         '550e8400-e29b-41d4-a716-446655440000'
       )
       expect(funnel).to be_a Fountain::Funnel
@@ -109,7 +110,7 @@ describe Fountain::Api::Funnels do
     end
 
     it 'filters non-standard arguments' do
-      funnel = Fountain::Api::Funnels.update(
+      funnel = described_class.update(
         '550e8400-e29b-41d4-a716-446655440000',
         custom_id: '3d67750a-dcf4-4ada-a3e4-ee44661949fc'
       )
@@ -140,7 +141,7 @@ describe Fountain::Api::Funnels do
     end
 
     it 'returns all stages for a funnel' do
-      stages = Fountain::Api::Funnels.list_stages(
+      stages = described_class.list_stages(
         '550e8400-e29b-41d4-a716-446655440000'
       )
       expect(stages).to be_an Array

--- a/spec/fountain/api/labels_spec.rb
+++ b/spec/fountain/api/labels_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Fountain::Api::Labels do
   before { Fountain.api_token = AUTH_TOKEN }
+
   after { Fountain.api_token = nil }
 
   let(:label) do
@@ -24,7 +25,7 @@ describe Fountain::Api::Labels do
     end
 
     it 'returns the applicants labels' do
-      labels = Fountain::Api::Labels.applicant_labels(
+      labels = described_class.applicant_labels(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(labels).to be_an Array
@@ -81,7 +82,7 @@ describe Fountain::Api::Labels do
     end
 
     it 'updates applicant labels' do
-      labels = Fountain::Api::Labels.update_applicant_label(
+      labels = described_class.update_applicant_label(
         '01234567-0000-0000-0000-000000000000', 'my_label'
       )
       expect(labels).to be_an Array
@@ -90,7 +91,7 @@ describe Fountain::Api::Labels do
     end
 
     it 'URI encodes labels' do
-      labels = Fountain::Api::Labels.update_applicant_label(
+      labels = described_class.update_applicant_label(
         '01234567-0000-0000-0000-000000000000', 'other-label'
       )
       expect(labels).to be_an Array
@@ -99,7 +100,7 @@ describe Fountain::Api::Labels do
     end
 
     it 'filters out non-standard arguments and formats completed_at date' do
-      labels = Fountain::Api::Labels.update_applicant_label(
+      labels = described_class.update_applicant_label(
         '01234567-0000-0000-0000-000000000000', 'New Label',
         completed: false, completed_at: Date.new(2018, 4, 3)
       )
@@ -120,7 +121,7 @@ describe Fountain::Api::Labels do
     end
 
     it 'returns the stages labels' do
-      labels = Fountain::Api::Labels.stage_labels(
+      labels = described_class.stage_labels(
         '11111111-0000-0000-0000-000000000000'
       )
       expect(labels).to be_an Array

--- a/spec/fountain/api/notes_spec.rb
+++ b/spec/fountain/api/notes_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe Fountain::Api::Notes do
   before { Fountain.api_token = AUTH_TOKEN }
+
   after { Fountain.api_token = nil }
 
   let(:note) do
@@ -34,7 +35,7 @@ describe Fountain::Api::Notes do
     end
 
     it 'returns the applicants notes' do
-      notes = Fountain::Api::Notes.list(
+      notes = described_class.list(
         '01234567-0000-0000-0000-000000000000'
       )
       expect(notes).to be_an Array
@@ -59,7 +60,7 @@ describe Fountain::Api::Notes do
     end
 
     it 'returns the created note' do
-      note = Fountain::Api::Notes.create(
+      note = described_class.create(
         '01234567-0000-0000-0000-000000000000',
         'This is a great candidate'
       )
@@ -78,7 +79,7 @@ describe Fountain::Api::Notes do
     end
 
     it 'deletes the applicant' do
-      result = Fountain::Api::Notes.delete(
+      result = described_class.delete(
         '01234567-0000-0000-0000-000000000000',
         '11111111-0000-0000-0000-000000000000'
       )
@@ -101,7 +102,7 @@ describe Fountain::Api::Notes do
     end
 
     it 'returns the created note' do
-      note = Fountain::Api::Notes.update(
+      note = described_class.update(
         '01234567-0000-0000-0000-000000000000',
         '11111111-0000-0000-0000-000000000000',
         'This is a better candidate'

--- a/spec/fountain/api/notes_spec.rb
+++ b/spec/fountain/api/notes_spec.rb
@@ -16,6 +16,15 @@ describe Fountain::Api::Notes do
       'user' => user
     }
   end
+  let(:note2) do
+    {
+      'id' => 'bc213c4a-3e58-4a0b-92f2-be980dd46ca9',
+      'content' => 'This candidate was ok',
+      'created_at' => '2017-12-15T14:25:07.123-08:00',
+      'updated_at' => '2017-12-15T14:25:07.123-08:00',
+      'user' => user
+    }
+  end
   let(:user) do
     {
       'name' => 'Ms. Tiana Hermiston',
@@ -55,6 +64,15 @@ describe Fountain::Api::Notes do
         )
         .to_return(
           body: note.to_json,
+          status: 200
+        )
+
+      stub_authed_request(:post, '/v2/applicants/01234567-0000-0000-0000-000000000001/notes')
+        .with(
+          body: { content: 'This candidate was ok' }.to_json
+        )
+        .to_return(
+          body: note2.to_json,
           status: 201
         )
     end
@@ -66,6 +84,15 @@ describe Fountain::Api::Notes do
       )
       expect(note).to be_a Fountain::Note
       expect(note.id).to eq '8f247b3a-a473-4dfd-81cc-46fb527a8823'
+    end
+
+    it 'handles a 201 Created response' do
+      note = described_class.create(
+        '01234567-0000-0000-0000-000000000001',
+        'This candidate was ok'
+      )
+      expect(note).to be_a Fountain::Note
+      expect(note.id).to eq 'bc213c4a-3e58-4a0b-92f2-be980dd46ca9'
     end
   end
 

--- a/spec/fountain/applicant_spec.rb
+++ b/spec/fountain/applicant_spec.rb
@@ -47,7 +47,7 @@ describe Fountain::Applicant do
     }
   end
 
-  let(:applicant) { Fountain::Applicant.new data }
+  let(:applicant) { described_class.new data }
 
   describe '#id' do
     it { expect(applicant.id).to eq '01234567-0000-0000-0000-000000000000' }

--- a/spec/fountain/applicants_spec.rb
+++ b/spec/fountain/applicants_spec.rb
@@ -26,7 +26,7 @@ describe Fountain::Applicants do
       next_cursor: 'cursor2'
     }
   end
-  let(:applicants) { Fountain::Applicants.new data }
+  let(:applicants) { described_class.new data }
 
   describe '#current_cursor' do
     it { expect(applicants.current_cursor).to eq 'cursor1' }
@@ -36,7 +36,7 @@ describe Fountain::Applicants do
     it { expect(applicants.next_cursor).to eq 'cursor2' }
   end
 
-  context 'no pagination returned' do
+  context 'when no pagination returned' do
     let(:pagination) { nil }
 
     describe '#current_cursor' do

--- a/spec/fountain/background_check_spec.rb
+++ b/spec/fountain/background_check_spec.rb
@@ -12,7 +12,7 @@ describe Fountain::BackgroundCheck do
       'report_id' => '4722c07dd9a10c3985ae432a'
     }
   end
-  let(:background_check) { Fountain::BackgroundCheck.new data }
+  let(:background_check) { described_class.new data }
 
   describe '#title' do
     it { expect(background_check.title).to eq 'Driver license check' }

--- a/spec/fountain/configuration_spec.rb
+++ b/spec/fountain/configuration_spec.rb
@@ -2,29 +2,29 @@
 
 require 'spec_helper'
 
-describe Fountain do
-  it 'should set default value for host_path option' do
-    expect(Fountain.host_path).to eq 'https://api.fountain.com'
+describe Fountain do # rubocop:disable RSpec/FilePath
+  it 'sets default value for host_path option' do
+    expect(described_class.host_path).to eq 'https://api.fountain.com'
   end
 
-  it 'should not have a default value for api_token option' do
-    expect(Fountain.api_token).to be_nil
+  it 'does not have a default value for api_token option' do
+    expect(described_class.api_token).to be_nil
   end
 
   describe '#configure' do
     before do
-      Fountain.configure do |config|
+      described_class.configure do |config|
         config.host_path = 'https://example.com'
         config.api_token = 'qwerty123456'
       end
     end
 
-    it 'should apply configured host_path option' do
-      expect(Fountain.host_path).to eq 'https://example.com'
+    it 'applies configured host_path option' do
+      expect(described_class.host_path).to eq 'https://example.com'
     end
 
-    it 'should apply configured api_token option' do
-      expect(Fountain.api_token).to eq 'qwerty123456'
+    it 'applies configured api_token option' do
+      expect(described_class.api_token).to eq 'qwerty123456'
     end
   end
 end

--- a/spec/fountain/document_signature_spec.rb
+++ b/spec/fountain/document_signature_spec.rb
@@ -10,7 +10,7 @@ describe Fountain::DocumentSignature do
       'status' => 'signed'
     }
   end
-  let(:document_signature) { Fountain::DocumentSignature.new data }
+  let(:document_signature) { described_class.new data }
 
   describe '#signature_id' do
     it { expect(document_signature.signature_id).to eq '123dfdsf' }

--- a/spec/fountain/field_spec.rb
+++ b/spec/fountain/field_spec.rb
@@ -11,7 +11,7 @@ describe Fountain::Field do
     }
   end
 
-  let(:field) { Fountain::Field.new data }
+  let(:field) { described_class.new data }
 
   describe '#question' do
     it { expect(field.question).to eq 'Foo' }

--- a/spec/fountain/funnel_spec.rb
+++ b/spec/fountain/funnel_spec.rb
@@ -43,7 +43,7 @@ describe Fountain::Funnel do
       'name' => 'San Francisco'
     }
   end
-  let(:funnel) { Fountain::Funnel.new data }
+  let(:funnel) { described_class.new data }
 
   describe '#id' do
     it { expect(funnel.id).to eq '1f62e031-46b2-4cc6-92da-400182d2c88b' }
@@ -78,8 +78,9 @@ describe Fountain::Funnel do
     it { expect(funnel.fields.map(&:class)).to eq [Fountain::Field] }
     it { expect(funnel.fields.map(&:question)).to eq ['Foo'] }
 
-    context 'no fields provided' do
+    context 'when no fields provided' do
       let(:fields) { nil }
+
       it { expect(funnel.fields).to eq [] }
     end
   end
@@ -89,8 +90,9 @@ describe Fountain::Funnel do
     it { expect(funnel.stages.map(&:class)).to eq [Fountain::Stage] }
     it { expect(funnel.stages.map(&:id)).to eq ['70d446ca-670d-44be-a728-6c3d1921fb97'] }
 
-    context 'no stages provided' do
+    context 'when no stages provided' do
       let(:stages) { nil }
+
       it { expect(funnel.stages).to eq [] }
     end
   end
@@ -107,8 +109,9 @@ describe Fountain::Funnel do
     it { expect(funnel.location).to be_an Fountain::Location }
     it { expect(funnel.location.id).to eq '7f88228c-cba9-4827-b71d-e81244c05d37' }
 
-    context 'no location provided' do
+    context 'when no location provided' do
       let(:location) { nil }
+
       it { expect(funnel.location).to be_nil }
     end
   end

--- a/spec/fountain/funnels_spec.rb
+++ b/spec/fountain/funnels_spec.rb
@@ -48,7 +48,7 @@ describe Fountain::Funnels do
       last: 3
     }
   end
-  let(:funnels) { Fountain::Funnels.new data }
+  let(:funnels) { described_class.new data }
 
   describe '#current_page' do
     it { expect(funnels.current_page).to eq 2 }
@@ -58,7 +58,7 @@ describe Fountain::Funnels do
     it { expect(funnels.last_page).to eq 3 }
   end
 
-  context 'no pagination returned' do
+  context 'when no pagination returned' do
     let(:pagination) { nil }
 
     describe '#current_page' do

--- a/spec/fountain/label_spec.rb
+++ b/spec/fountain/label_spec.rb
@@ -9,7 +9,7 @@ describe Fountain::Label do
       'completed' => true
     }
   end
-  let(:label) { Fountain::Label.new data }
+  let(:label) { described_class.new data }
 
   describe '#title' do
     it { expect(label.title).to eq 'Label 0' }

--- a/spec/fountain/location_spec.rb
+++ b/spec/fountain/location_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Fountain::Slot do
+describe Fountain::Location do
   let(:data) do
     {
       id: '7f88228c-cba9-4827-b71d-e81244c05d37',
@@ -10,7 +10,7 @@ describe Fountain::Slot do
     }
   end
 
-  let(:location) { Fountain::Location.new data }
+  let(:location) { described_class.new data }
 
   describe '#id' do
     it { expect(location.id).to eq '7f88228c-cba9-4827-b71d-e81244c05d37' }

--- a/spec/fountain/note_spec.rb
+++ b/spec/fountain/note_spec.rb
@@ -19,7 +19,7 @@ describe Fountain::Note do
       'id' => 'b32b08ce-4a32-4de7-983a-7e2e521405a2'
     }
   end
-  let(:note) { Fountain::Note.new data }
+  let(:note) { described_class.new data }
 
   describe '#id' do
     it { expect(note.id).to eq '8f247b3a-a473-4dfd-81cc-46fb527a8823' }
@@ -41,8 +41,9 @@ describe Fountain::Note do
     it { expect(note.user).to be_a Fountain::User }
     it { expect(note.user.id).to eq 'b32b08ce-4a32-4de7-983a-7e2e521405a2' }
 
-    context 'user is blank' do
+    context 'when user is blank' do
       let(:user_data) { '' }
+
       it { expect(note.user).to be_nil }
     end
   end

--- a/spec/fountain/secure_document_spec.rb
+++ b/spec/fountain/secure_document_spec.rb
@@ -18,7 +18,7 @@ describe Fountain::SecureDocument do
     }
   end
 
-  let(:document) { Fountain::SecureDocument.new data }
+  let(:document) { described_class.new data }
 
   describe '#id' do
     it { expect(document.id).to eq 'a71d7cf4-2d9d-4d4b-82ef-8894bbe78120' }

--- a/spec/fountain/slot_spec.rb
+++ b/spec/fountain/slot_spec.rb
@@ -15,7 +15,7 @@ describe Fountain::Slot do
     }
   end
 
-  let(:slot) { Fountain::Slot.new data }
+  let(:slot) { described_class.new data }
 
   describe '#id' do
     it { expect(slot.id).to eq '21d7d019-7940-44d1-a710-0a79dd71cfcd' }

--- a/spec/fountain/slots_spec.rb
+++ b/spec/fountain/slots_spec.rb
@@ -28,7 +28,7 @@ describe Fountain::Slots do
       last: 3
     }
   end
-  let(:slots) { Fountain::Slots.new data }
+  let(:slots) { described_class.new data }
 
   describe '#current_page' do
     it { expect(slots.current_page).to eq 2 }
@@ -38,7 +38,7 @@ describe Fountain::Slots do
     it { expect(slots.last_page).to eq 3 }
   end
 
-  context 'no pagination returned' do
+  context 'when no pagination returned' do
     let(:pagination) { nil }
 
     describe '#current_page' do

--- a/spec/fountain/stage_spec.rb
+++ b/spec/fountain/stage_spec.rb
@@ -10,7 +10,7 @@ describe Fountain::Stage do
       'type' => 'HiredStage'
     }
   end
-  let(:stage) { Fountain::Stage.new data }
+  let(:stage) { described_class.new data }
 
   describe '#id' do
     it { expect(stage.id).to eq '274d2929-e1d3-4535-b1b6-b5e4fc820f21' }

--- a/spec/fountain/transition_spec.rb
+++ b/spec/fountain/transition_spec.rb
@@ -9,7 +9,7 @@ describe Fountain::Transition do
       'created_at' => '2016-12-12T13:24:44.381-08:00'
     }
   end
-  let(:transition) { Fountain::Transition.new data }
+  let(:transition) { described_class.new data }
 
   describe '#stage_title' do
     it { expect(transition.stage_title).to eq 'Approved' }

--- a/spec/fountain/user_spec.rb
+++ b/spec/fountain/user_spec.rb
@@ -10,7 +10,7 @@ describe Fountain::User do
       'id' => 'b32b08ce-4a32-4de7-983a-7e2e521405a2'
     }
   end
-  let(:user) { Fountain::User.new data }
+  let(:user) { described_class.new data }
 
   describe '#id' do
     it { expect(user.id).to eq 'b32b08ce-4a32-4de7-983a-7e2e521405a2' }

--- a/spec/support/delegate_method_matcher.rb
+++ b/spec/support/delegate_method_matcher.rb
@@ -20,7 +20,7 @@ RSpec::Matchers.define :delegate_method do |method|
     rescue NoMethodError
       raise "#{@delegator} does not respond to #{@to}!"
     end
-    allow(@delegator).to receive(@to).and_return double('receiver')
+    allow(@delegator).to receive(@to).and_return double('receiver') # rubocop:disable RSpec/VerifiedDoubles
     allow(@delegator.send(@to)).to receive(method).and_return :called
     @delegator.send(@method) == :called
   end


### PR DESCRIPTION
It looks like Fountain have changed the expected response codes for the applicant and note APIs from a 201 Created to a 200 OK. 