### PR TITLE
Add wrapper for bulk advance multiple applicants

### DIFF
--- a/lib/fountain/api/applicants.rb
+++ b/lib/fountain/api/applicants.rb
@@ -144,14 +144,15 @@ module Fountain
       # @param [Hash] advance_options A hash of options to advance applicant
       #                 skip_automated_actions - `true` if you want to skip automated
       #                                          actions when advancing the applicant
+      #                 funnel_id - Used for bulk advancing applicants to a workflow-based funnel
       def self.advance_applicants(applicant_ids, stage_id, advance_options = {})
         response = request(
           "/v2/applicants/advance?#{stage_id}",
           method: :post,
           body: Util.slice_hash(
             advance_options,
-            :skip_automated_actions
-          ).merge(applicant_ids: applicant_ids)
+            :skip_automated_actions, :funnel_id
+          ).merge(ids: applicant_ids)
         )
         check_response response, Net::HTTPNoContent
         true

--- a/lib/fountain/api/applicants.rb
+++ b/lib/fountain/api/applicants.rb
@@ -138,6 +138,26 @@ module Fountain
       end
 
       #
+      # Advance multiple Applicants
+      # @param [String] applicant_id IDs of the Fountain applicants
+      # @param [String] Destination stage's ID
+      # @param [Hash] advance_options A hash of options to advance applicant
+      #                 skip_automated_actions - `true` if you want to skip automated
+      #                                          actions when advancing the applicant
+      def self.advance_applicants(applicant_ids, stage_id, advance_options = {})
+        response = request(
+          "/v2/applicants/advance?#{stage_id}",
+          method: :post,
+          body: Util.slice_hash(
+            advance_options,
+            :skip_automated_actions
+          ).merge(applicant_ids: applicant_ids)
+        )
+        check_response response, Net::HTTPNoContent
+        true
+      end
+
+      #
       # Get Interview Sessions
       # @param [String] applicant_id ID of the Fountain applicant
       # @return [[Fountain::Slot]]

--- a/lib/fountain/gem_version.rb
+++ b/lib/fountain/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Fountain
-  VERSION = '0.0.16'
+  VERSION = '0.0.17'
 end

--- a/spec/fountain/api/applicants_spec.rb
+++ b/spec/fountain/api/applicants_spec.rb
@@ -367,6 +367,33 @@ describe Fountain::Api::Applicants do
     end
   end
 
+  describe '.advance_applicants' do
+    before do
+      # Stubs for /v2/applicants/advance REST API
+      stub_authed_request(:post, '/v2/applicants/advance?stage-id')
+        .to_return(status: 204)
+
+      stub_authed_request(:post, '/v2/applicants/advance?stage-id')
+        .with(
+          body: {
+            ids: ['01234567-0000-0000-0000-000000000000'],
+            skip_automated_actions: true,
+          }.to_json
+        )
+        .to_return(status: 204)
+    end
+
+    it 'advances the applicants to a specific stage (ignoring non-standard arguments)' do
+      result = described_class.advance_applicants(
+        ['01234567-0000-0000-0000-000000000001'],
+        'stage-id',
+        skip_automated_actions: true,
+        invalid_arg: 'should not be included'
+      )
+      expect(result).to be true
+    end
+  end
+
   describe '.get_interview_sessions' do
     let(:slot) do
       {

--- a/spec/fountain/api/applicants_spec.rb
+++ b/spec/fountain/api/applicants_spec.rb
@@ -388,6 +388,7 @@ describe Fountain::Api::Applicants do
         ['01234567-0000-0000-0000-000000000001'],
         'stage-id',
         skip_automated_actions: true,
+        funnel_id: 'funnel-id',
         invalid_arg: 'should not be included'
       )
       expect(result).to be true


### PR DESCRIPTION
This creates the method `advance_applicants` which can but used to advance applicants in bulk

https://developer.fountain.com/reference/bulk-advance-multiple-applicants