### PR TITLE
Fix bug in Applicants#advance_applicants

### DIFF
--- a/lib/fountain/api/applicants.rb
+++ b/lib/fountain/api/applicants.rb
@@ -145,12 +145,12 @@ module Fountain
       #                 skip_automated_actions - `true` if you want to skip automated
       #                                          actions when advancing the applicant
       #                 funnel_id - Used for bulk advancing applicants to a workflow-based funnel
-      def self.advance_applicants(applicant_ids, stage_id, advance_options = {})
+      def self.advance_applicants(applicant_ids, stage_id, advanced_options = {})
         response = request(
-          "/v2/applicants/advance?#{stage_id}",
+          "/v2/applicants/advance?stage_id=#{stage_id}",
           method: :post,
           body: Util.slice_hash(
-            advance_options,
+            advanced_options,
             :skip_automated_actions, :funnel_id
           ).merge(ids: applicant_ids)
         )

--- a/spec/fountain/api/applicants_spec.rb
+++ b/spec/fountain/api/applicants_spec.rb
@@ -391,7 +391,7 @@ describe Fountain::Api::Applicants do
   describe '.advance_applicants' do
     before do
       # Stubs for /v2/applicants/advance REST API
-      stub_authed_request(:post, '/v2/applicants/advance?stage-id')
+      stub_authed_request(:post, '/v2/applicants/advance?stage_id=stage-id')
         .with(
           body: {
             skip_automated_actions: true,
@@ -401,7 +401,7 @@ describe Fountain::Api::Applicants do
         )
         .to_return(status: 204)
 
-      stub_authed_request(:post, '/v2/applicants/advance?stage-id')
+      stub_authed_request(:post, '/v2/applicants/advance?stage_id=stage-id')
         .with(
           body: {
             skip_automated_actions: true,


### PR DESCRIPTION
Per documentation, the `stage_id` needs to be passed through as a named query parameter.

https://developer.fountain.com/reference/post_v2-applicants-advance